### PR TITLE
Async overhaul and .NET 4.6

### DIFF
--- a/GiantBomb.Api.Tests/GiantBomb.Api.Tests.csproj
+++ b/GiantBomb.Api.Tests/GiantBomb.Api.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GiantBomb.Api.Tests</RootNamespace>
     <AssemblyName>GiantBomb.Api.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\GiantBomb-CSharp\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -40,8 +40,8 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/GiantBomb.Api.Tests/app.config
+++ b/GiantBomb.Api.Tests/app.config
@@ -8,4 +8,4 @@
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/GiantBomb.Api.Tests/packages.config
+++ b/GiantBomb.Api.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net452" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net46" />
 </packages>

--- a/GiantBomb.Api/GiantBomb.Api.csproj
+++ b/GiantBomb.Api/GiantBomb.Api.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GiantBomb.Api</RootNamespace>
     <AssemblyName>GiantBomb.Api</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\GiantBomb-CSharp\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -39,8 +39,8 @@
     <Reference Include="fastJSON">
       <HintPath>..\Dependencies\fastJSON.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -75,6 +75,7 @@
     <Compile Include="Resources\Regions.cs" />
     <Compile Include="Resources\Releases.cs" />
     <Compile Include="Resources\Search.cs" />
+    <Compile Include="TaskExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="GiantBomb.Api.nuspec" />

--- a/GiantBomb.Api/Properties/AssemblyInfo.cs
+++ b/GiantBomb.Api/Properties/AssemblyInfo.cs
@@ -12,6 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("5d910805-e5ae-48f0-8e39-d37104d7a91e")]
 
-[assembly: AssemblyVersion("2.2.1")]
-[assembly: AssemblyFileVersion("2.2.1")]
-[assembly: AssemblyInformationalVersion("2.2.1")]
+[assembly: AssemblyVersion("2.3.0")]
+[assembly: AssemblyFileVersion("2.3.0")]
+[assembly: AssemblyInformationalVersion("2.3.0")]

--- a/GiantBomb.Api/Resources/Games.cs
+++ b/GiantBomb.Api/Resources/Games.cs
@@ -1,30 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using GiantBomb.Api.Model;
-using RestSharp;
 
 namespace GiantBomb.Api {
     public partial class GiantBombRestClient {
 
         public Game GetGame(int id, string[] limitFields = null)
         {
-            return GetGameAsync(id, limitFields).Result;
+            return GetGameAsync(id, limitFields).WaitForResult();
         }
 
-        public async Task<Game> GetGameAsync(int id, string[] limitFields = null) {
-            return await GetSingleResourceAsync<Game>("game", ResourceTypes.Games, id, limitFields);
+        public Task<Game> GetGameAsync(int id, string[] limitFields = null)
+        {
+            return GetSingleResourceAsync<Game>("game", ResourceTypes.Games, id, limitFields);
         }
 
         public IEnumerable<Game> GetGames(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
         {
-            return GetGamesAsync(page, pageSize, limitFields).Result;
+            return GetGamesAsync(page, pageSize, limitFields).WaitForResult();
         }
 
-        public async Task<IEnumerable<Game>> GetGamesAsync(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null) {
-            return await GetListResourceAsync<Game>("games", page, pageSize, limitFields);
+        public Task<IEnumerable<Game>> GetGamesAsync(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
+        {
+            return GetListResourceAsync<Game>("games", page, pageSize, limitFields);
         }
     }
 }

--- a/GiantBomb.Api/Resources/Platforms.cs
+++ b/GiantBomb.Api/Resources/Platforms.cs
@@ -1,30 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using GiantBomb.Api.Model;
-using RestSharp;
 
 namespace GiantBomb.Api {
     public partial class GiantBombRestClient {
         public Platform GetPlatform(int id, string[] limitFields = null)
         {
-            return GetPlatformAsync(id, limitFields).Result;
+            return GetPlatformAsync(id, limitFields).WaitForResult();
         }
 
-        public async Task<Platform> GetPlatformAsync(int id, string[] limitFields = null) {
-            return await GetSingleResourceAsync<Platform>("platform", ResourceTypes.Platforms, id, limitFields);
+        public Task<Platform> GetPlatformAsync(int id, string[] limitFields = null) {
+            return GetSingleResourceAsync<Platform>("platform", ResourceTypes.Platforms, id, limitFields);
         }
 
         public IEnumerable<Platform> GetPlatforms(int page = 1, int pageSize = GiantBombBase.DefaultLimit,
             string[] limitFields = null)
         {
-            return GetPlatformsAsync(page, pageSize, limitFields).Result;
+            return GetPlatformsAsync(page, pageSize, limitFields).WaitForResult();
         }
 
-        public async Task<IEnumerable<Platform>> GetPlatformsAsync(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null) {
-            return await GetListResourceAsync<Platform>("platforms", page, pageSize, limitFields);
+        public Task<IEnumerable<Platform>> GetPlatformsAsync(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null) {
+            return GetListResourceAsync<Platform>("platforms", page, pageSize, limitFields);
         }
     }
 }

--- a/GiantBomb.Api/Resources/Regions.cs
+++ b/GiantBomb.Api/Resources/Regions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using GiantBomb.Api.Model;
 
@@ -11,22 +8,22 @@ namespace GiantBomb.Api
     {
         public Region GetRegion(int id, string[] limitFields = null)
         {
-            return GetRegionAsync(id, limitFields).Result;
+            return GetRegionAsync(id, limitFields).WaitForResult();
         }
 
-        public async Task<Region> GetRegionAsync(int id, string[] limitFields = null)
+        public Task<Region> GetRegionAsync(int id, string[] limitFields = null)
         {
-            return await GetSingleResourceAsync<Region>("region", ResourceTypes.Regions, id, limitFields);
+            return GetSingleResourceAsync<Region>("region", ResourceTypes.Regions, id, limitFields);
         }
 
         public IEnumerable<Region> GetRegions(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
         {
-            return GetRegionsAsync(page, pageSize, limitFields).Result;
+            return GetRegionsAsync(page, pageSize, limitFields).WaitForResult();
         }
 
-        public async Task<IEnumerable<Region>> GetRegionsAsync(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
+        public Task<IEnumerable<Region>> GetRegionsAsync(int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
         {
-            return await GetListResourceAsync<Region>("regions", page, pageSize, limitFields);
+            return GetListResourceAsync<Region>("regions", page, pageSize, limitFields);
         }
     }
 }

--- a/GiantBomb.Api/Resources/Releases.cs
+++ b/GiantBomb.Api/Resources/Releases.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using GiantBomb.Api.Model;
 
@@ -10,26 +7,26 @@ namespace GiantBomb.Api {
 
         public Release GetRelease(int id, string[] limitFields = null)
         {
-            return GetReleaseAsync(id, limitFields).Result;
+            return GetReleaseAsync(id, limitFields).WaitForResult();
         }
 
-        public async Task<Release> GetReleaseAsync(int id, string[] limitFields = null) {
-            return await GetSingleResourceAsync<Release>("release", ResourceTypes.Releases, id, limitFields);
+        public Task<Release> GetReleaseAsync(int id, string[] limitFields = null) {
+            return GetSingleResourceAsync<Release>("release", ResourceTypes.Releases, id, limitFields);
         }
 
         public IEnumerable<Release> GetReleasesForGame(int gameId, string[] limitFields = null)
         {
-            return GetReleasesForGameAsync(gameId, limitFields).Result;
+            return GetReleasesForGameAsync(gameId, limitFields).WaitForResult();
         }
 
-        public async Task<IEnumerable<Release>> GetReleasesForGameAsync(int gameId, string[] limitFields = null)
+        public Task<IEnumerable<Release>> GetReleasesForGameAsync(int gameId, string[] limitFields = null)
         {
             var filter = new Dictionary<string, object>()
                              {
                                  {"game", gameId}
                              };
 
-            return await GetListResourceAsync<Release>("releases", fieldList: limitFields, filterOptions: filter);
+            return GetListResourceAsync<Release>("releases", fieldList: limitFields, filterOptions: filter);
         }
 
         public IEnumerable<Release> GetReleasesForGame(Game game, string[] limitFields = null)

--- a/GiantBomb.Api/Resources/Search.cs
+++ b/GiantBomb.Api/Resources/Search.cs
@@ -1,74 +1,82 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using GiantBomb.Api.Model;
-using RestSharp;
 
 namespace GiantBomb.Api {
     public partial class GiantBombRestClient {
 
         public IEnumerable<Game> SearchForGames(string query, int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
         {
-            return SearchForGamesAsync(query, page, pageSize, limitFields).Result;
+            return SearchForGamesAsync(query, page, pageSize, limitFields).WaitForResult();
         }
 
-        public async Task<IEnumerable<Game>> SearchForGamesAsync(string query, int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null) {
-            var result = await InternalSearchForGames(query, page, pageSize, limitFields);
+        public Task<IEnumerable<Game>> SearchForGamesAsync(string query, int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
+        {
+            return InternalSearchForGames(query, page, pageSize, limitFields)
+                .ContinueWith<IEnumerable<Game>>(task =>
+                {
+                    var result = task.Result;
+                    if (result.StatusCode == GiantBombBase.StatusOk)
+                        return result.Results;
 
-            if (result.StatusCode == GiantBombBase.StatusOk)
-                return result.Results;
-
-            return null;
+                    return null;
+                });
         }
 
         public IEnumerable<Game> SearchForAllGames(string query, string[] limitFields = null)
         {
-            return SearchForAllGamesAsync(query, limitFields).Result;
+            return SearchForAllGamesAsync(query, limitFields).WaitForResult();
         }
 
-        public async Task<IEnumerable<Game>> SearchForAllGamesAsync(string query, string[] limitFields = null) {
+        public Task<IEnumerable<Game>> SearchForAllGamesAsync(string query, string[] limitFields = null) {
             var results = new List<Game>();
-            var result = await InternalSearchForGames(query, limitFields: limitFields);
-
-            if (result == null || result.StatusCode != GiantBombBase.StatusOk)
-                return null;
-
-            results.AddRange(result.Results);
-
-            if (result.NumberOfTotalResults > result.Limit) {
-                double remaining = Math.Ceiling(Convert.ToDouble(result.NumberOfTotalResults) / Convert.ToDouble(result.Limit));
-
-                // Start on page 2
-                for (var i = 2; i <= remaining; i++) {
-                    result = await InternalSearchForGames(query, i, result.Limit, limitFields);
-
-                    if (result.StatusCode != GiantBombBase.StatusOk)
-                        break;
+            return InternalSearchForGames(query, limitFields: limitFields).
+                ContinueWith<IEnumerable<Game>>(task =>
+                {
+                    var result = task.Result;
+                    if (result == null || result.StatusCode != GiantBombBase.StatusOk)
+                        return null;
 
                     results.AddRange(result.Results);
-                }
-            }
 
-            // FIX: Clean duplicates that GiantBomb returns
-            // Can only do it if we have IDs in the resultset
-            if (limitFields == null || limitFields.Contains("id"))
-            {
-                results = results.Distinct(new GameDistinctComparer()).ToList();
-            }
+                    if (result.NumberOfTotalResults > result.Limit)
+                    {
+                        double remaining = Math.Ceiling(Convert.ToDouble(result.NumberOfTotalResults) / Convert.ToDouble(result.Limit));
 
-            return results;
+                        // Start on page 2
+                        for (var i = 2; i <= remaining; i++)
+                        {
+                            // HACK: This is not ideal. We'd like this to be a continue chain, but that is a future
+                            // enhancement.
+                            result = InternalSearchForGames(query, i, result.Limit, limitFields).WaitForResult();
+                            if (result.StatusCode != GiantBombBase.StatusOk)
+                                break;
+
+                            results.AddRange(result.Results);
+                        }
+                    }
+
+                    // FIX: Clean duplicates that GiantBomb returns
+                    // Can only do it if we have IDs in the resultset
+                    if (limitFields == null || limitFields.Contains("id"))
+                    {
+                        results = results.Distinct(new GameDistinctComparer()).ToList();
+                    }
+
+                    return results;
+                });
         }
 
-        internal async Task<GiantBombResults<Game>> InternalSearchForGames(string query, int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
+        internal Task<GiantBombResults<Game>> InternalSearchForGames(string query, int page = 1, int pageSize = GiantBombBase.DefaultLimit, string[] limitFields = null)
         {
             var request = GetListResource("search", page, pageSize, limitFields);
 
             request.AddParameter("query", query);
             request.AddParameter("resources", "game");
 
-            return await ExecuteAsync<GiantBombResults<Game>>(request);
+            return ExecuteAsync<GiantBombResults<Game>>(request);
         }
     }
 }

--- a/GiantBomb.Api/TaskExtensions.cs
+++ b/GiantBomb.Api/TaskExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GiantBomb.Api
+{
+    public static class TaskExtensions
+    {
+        public static T WaitForResult<T>(this Task<T> task, int millisecondsToWait = 0)
+        {
+            task.Wait(millisecondsToWait);
+            if (task.IsFaulted && task.Exception != null)
+                throw task.Exception;
+
+            return task.Result;
+        }
+    }
+}

--- a/GiantBomb.Api/packages.config
+++ b/GiantBomb.Api/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net452" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net46" />
 </packages>

--- a/GiantBomb.Api/readme.txt
+++ b/GiantBomb.Api/readme.txt
@@ -1,6 +1,10 @@
 GiantBomb C#
 ------------
 
+## 2.3.0
+- Updated to .NET Framework 4.6
+- Total overhaul of async code to be truly async using ContinueWith, no more 'await' in the library
+
 ## 2.2.1
 
 - Better error handling for API exceptions

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,10 @@
 GiantBomb C#
 ------------
 
+## 2.3.0
+- Updated to .NET Framework 4.6
+- Total overhaul of async code to be truly async using ContinueWith, no more 'await' in the library
+
 ## 2.2.1
 
 - Better error handling for API exceptions


### PR DESCRIPTION
So this is a relatively big change set, so I wanted to leave a quick note about it.

Your initial async implementation fell in to a relatively common async/await trap that many (including myself) have fallen in to. You were awaiting your own async tasks deep in the library, creating task contention and making the asynchronous flow very choppy. In effect, it wasn't very async.

The fix to the problem is to basically remove all uses of await from the library, and instead use a little gem known as ContinueWith. ContinueWith basically says "Give me the task prior to myself, let me do some processing, and I will return a task for you to then continue, or wait". It sets up task chaining in a very asynchronous way. In this case, we use ContinueWith to do the results processing that used to be 'await'ed on. Now the only thing that needs to truly wait for the final task chain to complete is the end consumer, using await or task.Wait(), or even our friend ContinueWith; The option is up to the implementing developer.

To make this work with the non-async versions, I added a helper extension method called WaitForResult(), which simply takes a Task of T and waits for it to finish it, giving us the result. All non-async methods effectively now WaitForResult() an async method. The old implementation of 'AsyncMethod().Result' only worked because of the deep awaits in the async methods. If the async methods were not effectively blocking, the old non-async methods would have suffered from race conditions as the task would not have completed when the result was queried.

If you have any questions about what I did, or why, please let me know. I'm happy to explain anything.