### PR TITLE
restsharp: Update to v107

### DIFF
--- a/GiantBomb.Api/GiantBomb.Api.csproj
+++ b/GiantBomb.Api/GiantBomb.Api.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>GiantBomb.Api</AssemblyName>
     <RootNamespace>GiantBomb.Api</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.6.0</Version>
+    <Version>3.0.0</Version>
     <Authors>kayub</Authors>
     <Company>kayub</Company>
     <Product>GiantBomb API (C#)</Product>
@@ -25,8 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.12.0" />
-    <PackageReference Include="RestSharp.Serializers.SystemTextJson" Version="106.12.0" />
+    <PackageReference Include="RestSharp" Version="107.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GiantBomb.Api/IGiantBombRestClient.cs
+++ b/GiantBomb.Api/IGiantBombRestClient.cs
@@ -280,12 +280,12 @@ namespace GiantBomb.Api
         /// Execute a manual REST request
         /// </summary>
         /// <param name="request">The RestRequest to execute (will use client credentials)</param>
-        IRestResponse Execute(RestRequest request);
+        RestResponse Execute(RestRequest request);
 
         /// <summary>
         /// Execute a manual REST request
         /// </summary>
         /// <param name="request">The RestRequest to execute (will use client credentials)</param>
-        Task<IRestResponse> ExecuteAsync(RestRequest request);
+        Task<RestResponse> ExecuteAsync(RestRequest request);
     }
 }


### PR DESCRIPTION
This is a breaking change because IRestResponse/IRestRequest was removed affecting IGiantBombRestClient.Execute(Async)